### PR TITLE
Support yahoo-finance 1.0.0, set version in gemspec.

### DIFF
--- a/ledger_get_prices.gemspec
+++ b/ledger_get_prices.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  spec.add_runtime_dependency "yahoo-finance"
+  spec.add_runtime_dependency "yahoo-finance", "~> 1.0.0"
 end

--- a/lib/ledger_get_prices.rb
+++ b/lib/ledger_get_prices.rb
@@ -76,7 +76,7 @@ module LedgerGetPrices
 
         while quote_strings.length > 0 && result.nil?
           begin
-            result = YahooFinance.historical_quotes(
+            result = YahooFinance::Client.new.historical_quotes(
               quote_strings.shift, start_date: start_date, end_date: end_date, period: :daily)
           rescue OpenURI::HTTPError => e
             err = e


### PR DESCRIPTION
Tried just running it and it was missing this, I guess yahoo-finance has a new API. Anyway this makes ledger-get-prices work with that new API.
